### PR TITLE
Fix incorrect reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -204,7 +204,7 @@ The {{MediaStreamTrackSignal}} dictionary has the following fields:
     * `"request-frame"`, tells the source to produce a new frame.
     * `"set-min-frame-rate"`, tells the source or track to maintain a
       minimum frame rate.
-* {{MediaStreamTrackSignal/fps}} a numeric attribute representing a frame rate in frames per
+* {{MediaStreamTrackSignal/frameRate}} a numeric attribute representing a frame rate in frames per
   second, used together with `"set-min-frame-rate"` control signals.
 
 This set of control signals is intended to be extensible, so it is possible that new signal types


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-insertable-streams/pull/9.html" title="Last updated on Jan 27, 2021, 10:34 AM UTC (0b69a00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-insertable-streams/9/4361e26...0b69a00.html" title="Last updated on Jan 27, 2021, 10:34 AM UTC (0b69a00)">Diff</a>