### PR TITLE
fix of Frame's free method with destroy()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -165,7 +165,7 @@ itself a {{MediaStreamTrack}}. If the {{MediaStreamTrackGenerator/[kind]}} attri
 the stream will accept {{AudioFrame}} objects and fail with any other type. If
 {{MediaStreamTrackGenerator/[kind]}} is `"video"`, the stream will accept {{VideoFrame}} objects
 and fail with any other type. When a frame is written to {{MediaStreamTrackGenerator/writable}},
-the frame's `close()` method is automatically invoked, so that its internal resources are no longer
+the frame's `destroy()` method is automatically invoked, so that its internal resources are no longer
 accessible from JavaScript.
 </dd>
 <dt><dfn attribute for=MediaStreamTrackProcessor>readableControl</dfn></dt>
@@ -256,7 +256,7 @@ let transformer = new TransformStream({
    async transform(videoFrame, controller) {
       let facePosition = detectFace(videoFrame);
       let newFrame = blurBackground(videoFrame.data, facePosition);
-      videoFrame.close();
+      videoFrame.destroy();
       controller.enqueue(newFrame);
   }
 });


### PR DESCRIPTION
Here is just a quick fix. WebCodecs' spec says free method of Frame is `destroy()`.
https://wicg.github.io/web-codecs/#dom-videoframe-destroy

I'd appreciate it if you would confirm it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ytakio/mediacapture-insertable-streams/pull/15.html" title="Last updated on Feb 9, 2021, 7:50 AM UTC (9d77c2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-insertable-streams/15/90366d1...ytakio:9d77c2d.html" title="Last updated on Feb 9, 2021, 7:50 AM UTC (9d77c2d)">Diff</a>