### PR TITLE
Add a note to close VideoFrames explicitly

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -111,7 +111,7 @@ does not give the UA enough flexibility to choose the buffering policy.
 <p class="note">
 Authors are encouraged to call close() on output {{VideoFrame|VideoFrames}} immediately when frames are no longer needed.
 The underlying media resources are owned by the {{MediaStreamTrack}}'s source.
-Failing to release them (or waiting for garbage collection) can cause the source to stop emiting {{VideoFrame|VideoFrames}}.
+Failing to release them (or waiting for garbage collection) can cause the source to stop emitting new {{VideoFrame|VideoFrames}}.
 </p>
 
 ### Interface definition ### {#track-processor-interface}

--- a/index.bs
+++ b/index.bs
@@ -320,6 +320,7 @@ It is defined by running the following steps.
 2. Return [=a promise resolved with=] undefined.
 
 </dd>
+</dl>
 
 <p class="note">
 When the media data is sent to a track, the UA may apply processing
@@ -328,6 +329,7 @@ to the track satisfies the track's constraints. Each track may receive a
 different version of the media data depending on its constraints.
 </p>
 
+<dl>
 <dt><dfn attribute for=VideoTrackGenerator>muted</dfn></dt>
 <dd>Mutes the {{VideoTrackGenerator}}. The getter steps are to return
 [=this=].`[[isMuted]]`. The setter steps, given a value |newValue|, are as follows:

--- a/index.bs
+++ b/index.bs
@@ -108,6 +108,12 @@ associated {{ReadableStream}} only when a read request has been issued on
 the stream. The idea is to avoid the stream's internal buffering, which
 does not give the UA enough flexibility to choose the buffering policy.
 
+<p class="note">
+Authors are encouraged to call close() on output {{VideoFrame|VideoFrames}} immediately when frames are no longer needed.
+The underlying media resources are owned by the {{MediaStreamTrack}}'s source.
+Failing to release them (or waiting for garbage collection) can cause the source to stop emiting {{VideoFrame|VideoFrames}}.
+</p>
+
 ### Interface definition ### {#track-processor-interface}
 
 <pre class="idl">
@@ -209,6 +215,8 @@ It is defined by running the following steps:
 </dl>
 
 ### Handling interaction with the track ### {#processor-handling-interaction-with-track}
+<dl>
+<dd>
 When the `[[track]]` of a {{MediaStreamTrackProcessor}} |processor| delivers a
 frame to |processor|, the UA MUST execute the [=handleNewFrame=] algorithm
 with |processor| as parameter.

--- a/index.bs
+++ b/index.bs
@@ -215,8 +215,6 @@ It is defined by running the following steps:
 </dl>
 
 ### Handling interaction with the track ### {#processor-handling-interaction-with-track}
-<dl>
-<dd>
 When the `[[track]]` of a {{MediaStreamTrackProcessor}} |processor| delivers a
 frame to |processor|, the UA MUST execute the [=handleNewFrame=] algorithm
 with |processor| as parameter.
@@ -232,13 +230,11 @@ It is defined by running the following steps:
 At any time, the UA MAY [=list/remove=] any frame from |processor|.`[[queue]]`.
 The UA may decide to remove frames from |processor|.`[[queue]]`, for example,
 to prevent resource exhaustion or to improve performance in certain situations.
-</dd>
 
 <p class="note">
 The application may detect that frames have been dropped by noticing that there
 is a gap in the timestamps of the frames.
 </p>
-</dl>
 
 When the `[[track]]` of a {{MediaStreamTrackProcessor}} |processor|
 [=track|ends=], the [=processorClose=] algorithm must be
@@ -318,6 +314,13 @@ The <dfn>writeFrame</dfn> algorithm is given a |generator| and a |frame| as inpu
 1. Run the [=Close VideoFrame=] algorithm with |frame|.
 1. Return [=a promise resolved with=] undefined.
 
+The <dfn>closeWritable</dfn> algorithm is given a |generator| as input.
+It is defined by running the following steps.
+1. For each track `t` sourced from |generator|, [=track|end=] `t`.
+2. Return [=a promise resolved with=] undefined.
+
+</dd>
+
 <p class="note">
 When the media data is sent to a track, the UA may apply processing
 (e.g., cropping and downscaling) to ensure that the media data sent
@@ -325,12 +328,6 @@ to the track satisfies the track's constraints. Each track may receive a
 different version of the media data depending on its constraints.
 </p>
 
-The <dfn>closeWritable</dfn> algorithm is given a |generator| as input.
-It is defined by running the following steps.
-1. For each track `t` sourced from |generator|, [=track|end=] `t`.
-2. Return [=a promise resolved with=] undefined.
-
-</dd>
 <dt><dfn attribute for=VideoTrackGenerator>muted</dfn></dt>
 <dd>Mutes the {{VideoTrackGenerator}}. The getter steps are to return
 [=this=].`[[isMuted]]`. The setter steps, given a value |newValue|, are as follows:


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-transform/pull/119.html" title="Last updated on Apr 3, 2025, 2:16 PM UTC (3461c8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-transform/119/9f59da8...youennf:3461c8d.html" title="Last updated on Apr 3, 2025, 2:16 PM UTC (3461c8d)">Diff</a>