### PR TITLE
Update Makefile to use spec-generator for remote builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LOCAL_BIKESHED := $(shell command -v bikeshed 2> /dev/null)
 
 index.html: index.bs
 ifndef LOCAL_BIKESHED
-	curl https://api.csswg.org/bikeshed/ -F file=@$< > $@
+	curl https://www.w3.org/publications/spec-generator/ -F type=bikeshed-spec -F file=@$< > $@
 else
 	bikeshed spec
 endif


### PR DESCRIPTION
This updates the `curl` command in the makefile to use spec-generator, since the CSSWG Bikeshed service was discontinued.

I verified that the remote code path works as expected and produces output similar to the current ED.